### PR TITLE
Extract JobCardImage, don't render image until logoUrl is fetched

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import LearningResources from '../pages/learning-resources'
 import GetInTouch from '../pages/get-in-touch'
 import IndividualJobPage from '../pages/individual-job'
 import PostAJob from '../pages/post-a-job'
-import Thanks from '../pages/thanks'
+import Thanks from '../pages/Thanks'
 
 import * as ROUTES from '../constants/routes'
 

--- a/src/components/JobCard.js
+++ b/src/components/JobCard.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { storage } from '../firebase/firebase'
 import { motion } from 'framer-motion'
+import JobCardImage from './JobCardImage'
 
 const JobCard = ({ job }) => {
   const [logoUrl, setLogoUrl] = useState()
@@ -57,12 +58,7 @@ const JobCard = ({ job }) => {
             delay: 0.1,
           }}
         />
-        <img
-          data-cy={`job-card-image-${job.id}`}
-          src={logoUrl}
-          alt={`${job.companyName} Logo`}
-          className='my-auto w-full'
-        />
+        <JobCardImage logoUrl={logoUrl} job={job}/>
       </div>
 
       <div className='w-full md:w-11/12 flex justify-between md:pl-6'>

--- a/src/components/JobCardImage.js
+++ b/src/components/JobCardImage.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const JobCardImage = ({logoUrl, job}) => {
+  if (logoUrl) {
+    return (
+      <img
+        data-cy={`job-card-image-${job.id}`}
+        src={logoUrl}
+        alt={`${job.companyName} Logo`}
+        className='my-auto w-full'
+      />
+    )
+  } else {
+    return ''
+  }
+}
+
+export default JobCardImage


### PR DESCRIPTION
Just a quick one! I noticed that on load of the job board page that the company logos rendered a broken image for a second before the real image loads in.

Example of broken images: https://c.seanwash.com/1592365071.mov

This PR:

- Extracts the JobCard image into its own component, JobCardImage
- Alters JobCardImage so that it doesn't render an image element until logoUrl is present.