### PR TITLE
Fix duplicate form input id `email`

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -45,7 +45,7 @@ const Footer = () => {
           <div className='flex flex-col md:flex-row justify-center items-center'>
             <label
               className='text-blue-500 text-lg md:mr-6 font-semibold text-center md:text-left'
-              htmlFor='email'
+              htmlFor='newsletter-email'
             >
               Sign up for our mailing list!
             </label>
@@ -54,7 +54,7 @@ const Footer = () => {
               data-cy='mailing-list-signup'
               type='email'
               className='px-4 py-1 w-full md:w-2/5 my-3 md:my-0'
-              id='email'
+              id='newsletter-email'
               autoComplete='off'
               onBlur={(e) => setEmail(e.target.value)}
               name='email'


### PR DESCRIPTION
Another quick one, I noticed in the console that one some pages there are two inputs with the same ID `email`. The first comes from the Netlify honey pot, and the second comes from the newsletter subscription form.

This PR changes the input id and label htmlFor attrs to `newsletter-email`. A bonus is that clicking on the label now focuses the newsletter input instead of the hidden honeypot input.