### PR TITLE
Issue #85, Add placeholder to PostAJobForm.js URL Inputs

### DIFF
--- a/src/components/form/PostAJobForm.js
+++ b/src/components/form/PostAJobForm.js
@@ -220,7 +220,7 @@ const PostAJobForm = ({
                     name='howToApply'
                     className='input'
                     type='text'
-                    placeholder='https://'
+                    placeholder='http://'
                   ></Field>
 
                   <ErrorMessage
@@ -280,7 +280,7 @@ const PostAJobForm = ({
                         className='input'
                         title='url of the company'
                         type='url'
-                        placeholder='https://'
+                        placeholder='http://'
                       />
 
                       <ErrorMessage

--- a/src/components/form/PostAJobForm.js
+++ b/src/components/form/PostAJobForm.js
@@ -220,6 +220,7 @@ const PostAJobForm = ({
                     name='howToApply'
                     className='input'
                     type='text'
+                    placeholder='https://'
                   ></Field>
 
                   <ErrorMessage
@@ -279,6 +280,7 @@ const PostAJobForm = ({
                         className='input'
                         title='url of the company'
                         type='url'
+                        placeholder='https://'
                       />
 
                       <ErrorMessage


### PR DESCRIPTION
Issue #85 

Added placeholders of 'http://' rather than 'https://' to be explicit that 'http://' was a valid input for these fields.  

