### PR TITLE
Disable 'apply' buttons on job listing preview

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -22,6 +22,14 @@
   @apply shadow-md scale-110 duration-100;
 }
 
+.btn-disabled {
+  @apply opacity-50
+}
+
+.btn-disabled:hover {
+  @apply shadow scale-100 cursor-not-allowed
+}
+
 /*--Input--*/
 
 .input {

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -23,11 +23,11 @@
 }
 
 .btn-disabled {
-  @apply opacity-50
+  @apply opacity-50;
 }
 
 .btn-disabled:hover {
-  @apply shadow scale-100 cursor-not-allowed
+  @apply shadow scale-100;
 }
 
 /*--Input--*/

--- a/src/components/JobTemplate.js
+++ b/src/components/JobTemplate.js
@@ -147,7 +147,9 @@ const JobTemplate = ({ logo, props }) => {
                   <p className='opacity-75 hover:opacity-100'>Visit website</p>
                 </a>
                 <a data-cy='how-to-apply' href={props.howToApply}>
-                  <button className='hidden md:block btn btn-teal mt-8 w-full' disabled={isDisabled}>
+                  <button
+                    disabled={isDisabled}
+                    className={'hidden md:block btn btn-teal mt-8 w-full' + (isDisabled ? ' btn-disabled' : '')}>
                     Apply
                   </button>
                 </a>
@@ -158,7 +160,9 @@ const JobTemplate = ({ logo, props }) => {
 
         <div>
           <a data-cy='how-to-apply-bottom' href={props.howToApply}>
-            <button className='btn btn-teal mt-8 w-full md:w-auto' disabled={isDisabled}>
+            <button
+              disabled={isDisabled}
+              className={'btn btn-teal mt-8 w-full md:w-auto' + (isDisabled ? ' btn-disabled' : '')}>
               Apply
             </button>
           </a>

--- a/src/components/JobTemplate.js
+++ b/src/components/JobTemplate.js
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { storage } from '../firebase/firebase'
+import { useLocation } from 'react-router-dom'
 
 const JobTemplate = ({ logo, props }) => {
+  let { pathname } = useLocation()
+  const isDisabled = pathname.indexOf('/job-board/') !== 0
+
   const [companyLogo, setCompanyLogo] = useState(undefined)
 
   function readLogo(logo) {
@@ -143,7 +147,7 @@ const JobTemplate = ({ logo, props }) => {
                   <p className='opacity-75 hover:opacity-100'>Visit website</p>
                 </a>
                 <a data-cy='how-to-apply' href={props.howToApply}>
-                  <button className='hidden md:block btn btn-teal mt-8 w-full'>
+                  <button className='hidden md:block btn btn-teal mt-8 w-full' disabled={isDisabled}>
                     Apply
                   </button>
                 </a>
@@ -154,7 +158,7 @@ const JobTemplate = ({ logo, props }) => {
 
         <div>
           <a data-cy='how-to-apply-bottom' href={props.howToApply}>
-            <button className='btn btn-teal mt-8 w-full md:w-auto'>
+            <button className='btn btn-teal mt-8 w-full md:w-auto' disabled={isDisabled}>
               Apply
             </button>
           </a>


### PR DESCRIPTION
Hi Drew,

Thanks for letting me chip in!

I disabled the buttons in the JobTemplate based on the route per your suggestion, but it's still possible to focus the buttons by keyboard and follow the links.

The linter raises an issue when I conditionally assign a '#' to the href attribute, but we could omit the links altogether on the preview page. What would you suggest? 