### PR TITLE
re: issue #97 - Add 'Find a Job' link to mobile nav

### DIFF
--- a/cypress/integration/components/navbar_spec.js
+++ b/cypress/integration/components/navbar_spec.js
@@ -2,7 +2,7 @@ describe('navbar test', () => {
     // tests that every link works, should probably add some tests around which one is showing / hidden at different screensizes
     it('tests the mobile nav', () => {
         cy.visit('/')
-        cy.get('[data-cy=mobile-nav]>ul>li>a').should('have.length', 4)
+        cy.get('[data-cy=mobile-nav]>ul>li>a').should('have.length', 5)
             .each( (item) => {
                 cy.visit(item[0].href)
             })

--- a/cypress/integration/navbar_spec.js
+++ b/cypress/integration/navbar_spec.js
@@ -1,6 +1,6 @@
 describe('navbar test', () => {
     it('checks all links in the navbar are working correctly', () => {
-        cy.visit("baseUrl")
+        cy.visit('/')
         cy.get('nav>ul>li')
         .each( (el) => {
             if(el === 'a'){

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -36,6 +36,16 @@ const Nav = () => {
         >
           <li className='pt-3 pb-2 border-b-2 border-gray-300'>
             <NavLink
+              to='/job-board'
+              className='hover:opacity-100 opacity-75 '
+              activeClassName='opacity-100'
+            >
+              Find a Job
+            </NavLink>
+          </li>
+
+          <li className='pt-3 pb-2 border-b-2 border-gray-300'>
+            <NavLink
               className='hover:opacity-100 opacity-75 '
               to={ROUTES.LEARNING}
               activeClassName='opacity-100'


### PR DESCRIPTION
Adds a job board link to the mobile nav.

I also updated the navbar component and integration tests. The integration test was requesting "http://localhost:3000/baseUrl" because the visit command automatically prefixes arguments with the baseUrl value.