### PR TITLE
Feature/fix job listing list item style bug

### DIFF
--- a/src/components/JobTemplate.js
+++ b/src/components/JobTemplate.js
@@ -46,7 +46,7 @@ const JobTemplate = ({ logo, props }) => {
       children.forEach((child) => {
         const childTag = child.tagName
         child.classList = quillStyle[childTag]
-        if (child.hasChildren) {
+        if (child.hasChildNodes()) {
           const grandChildren = [...child.children]
           styleChildren(grandChildren)
         }

--- a/src/components/JobTemplate.js
+++ b/src/components/JobTemplate.js
@@ -45,6 +45,7 @@ const JobTemplate = ({ logo, props }) => {
     function styleChildren(children) {
       children.forEach((child) => {
         const childTag = child.tagName
+        child.style = ''
         child.classList = quillStyle[childTag]
         if (child.hasChildNodes()) {
           const grandChildren = [...child.children]


### PR DESCRIPTION
Hi Drew,

I think my first commit resolves the list item style issue. However, while browsing the other sample job descriptions I noticed a few other styling issues. 

For example, the 'Test' job at 'Great Company' has bold, black links:

<img width="562" alt="job description black links" src="https://user-images.githubusercontent.com/44448047/87972429-80998b80-ca8c-11ea-90eb-b6cfac464de7.png">

The link style is applied inline to the element. Do you think the Quill editor is applying it by default?

On line 48 of the JobTemplate, I tried resetting the style attribute to an empty string and fixed the issue:

<img width="549" alt="job description teal links" src="https://user-images.githubusercontent.com/44448047/87972865-454b8c80-ca8d-11ea-9a28-b61c37f2dac8.png">

But I'm concerned this approach could create other bugs! What do you think?
