### PR TITLE
bugfix: Display job title on PostAJob Preview

### DIFF
--- a/cypress/integration/components/post_a_job_form_spec.js
+++ b/cypress/integration/components/post_a_job_form_spec.js
@@ -6,7 +6,7 @@ describe('post a job form', () => {
     it('tests the form exists with all expected fields', () => {
         cy.get("[data-cy='status-bar']>svg>circle").first().should('not.have.attr', 'fill-opacity')
         cy.get("[data-cy='post-a-job-form']")
-        cy.get('input[name="jobTitle"]')
+        cy.get('input[name="jobtitle"]')
         cy.get('select[name="roleFocus"]')
         cy.get('select[name="positionType"]')
         // Quill Input
@@ -25,7 +25,7 @@ describe('post a job form', () => {
         cy.get('.input-error').should('have.length', 10)
     })
     it('tests inputs all the form fields', () => {
-        cy.get('input[name="jobTitle"]').type('Junior Developer').should('value', 'Junior Developer')
+        cy.get('input[name="jobtitle"]').type('Junior Developer').should('value', 'Junior Developer')
         cy.get('select[name="roleFocus"]').select('Front-end').should('value', 'Front-end')
         cy.get('select[name="positionType"]').select('Full-time').should('value', 'Full-time')
         // Quill Input

--- a/src/components/form/PostAJobForm.js
+++ b/src/components/form/PostAJobForm.js
@@ -16,8 +16,6 @@ const PostAJobForm = ({
 }) => {
   const [fileValue, setFileValue] = useState(undefined)
 
-  console.log(jobData)
-
   function recievingLogo(logo) {
     setFileValue(logo)
     recievingLogo2(logo)
@@ -27,7 +25,7 @@ const PostAJobForm = ({
     <div className='lg:w-3/5 mx-auto'>
       <Formik
         initialValues={{
-          jobTitle: jobData ? `${jobData.jobTitle}` : '',
+          jobtitle: jobData ? `${jobData.jobtitle}` : '',
           roleFocus: jobData ? `${jobData.roleFocus}` : '',
           positionType: jobData ? `${jobData.positionType}` : '',
           jobDescription: jobData ? `${jobData.jobDescription}` : '',
@@ -40,7 +38,7 @@ const PostAJobForm = ({
           companyHQ: jobData ? `${jobData.companyHQ}` : '',
         }}
         validationSchema={Yup.object({
-          jobTitle: Yup.string().required('Job title is a required field.'),
+          jobtitle: Yup.string().required('Job title is a required field.'),
           roleFocus: Yup.string().required('Please select a focus area.'),
           positionType: Yup.string().required('Please select a position type.'),
           jobDescription: Yup.string().required(
@@ -87,14 +85,14 @@ const PostAJobForm = ({
 
                   <Field
                     id='job-title'
-                    name='jobTitle'
+                    name='jobtitle'
                     className='input'
                     type='text'
                     autoComplete='off'
                   ></Field>
 
                   <ErrorMessage
-                    name='jobTitle'
+                    name='jobtitle'
                     component='span'
                     className='input-error'
                   />


### PR DESCRIPTION
### Job titles are not displaying on the PostAJob preview.

I tracked this down to a typo in PostAJob at line 52:

<img width="539" alt="PostAJob" src="https://user-images.githubusercontent.com/44448047/88416109-39b9d780-cda5-11ea-9ec0-3a37012b238b.png">

Job titles are correctly displayed on the Job Board because JobTemplate expects the typo:

<img width="490" alt="JobTemplate" src="https://user-images.githubusercontent.com/44448047/88416405-cb294980-cda5-11ea-8526-cfc0f8c4d1a4.png">

I can think of two ways to fix this issue:

1. Make the codebase consistent. This pull request updates the JobForm, validation, and tests with the typo.

2. Correct the typo and use the Firebase console to update all existing job posts to match.

What do you think? I'm leaning towards #2, but it's your call!

