### PR TITLE
Feature/add validation to PostAJobForm company logo field

### DIFF
--- a/cypress/integration/components/post_a_job_form_spec.js
+++ b/cypress/integration/components/post_a_job_form_spec.js
@@ -22,7 +22,7 @@ describe('post a job form', () => {
     })
     it('tests the form for error messages', () => {
         cy.get("[data-cy='next-step-button']").click()
-        cy.get('.input-error').should('have.length', 10)
+        cy.get('.input-error').should('have.length', 11)
     })
     it('tests inputs all the form fields', () => {
         cy.get('input[name="jobtitle"]').type('Junior Developer').should('value', 'Junior Developer')
@@ -39,7 +39,7 @@ describe('post a job form', () => {
         // Logo Upload
         cy.fixture('SnakeholeLoungeLogo.png').then( fileContent => {
             cy.get("[data-cy='company-logo-upload']").upload(
-                { fileContent, fileName: 'SnakeholeLoungeLogo.png', mimeType: 'image/*' },
+                { fileContent, fileName: 'SnakeholeLoungeLogo.png', mimeType: 'image/png' },
                 { subjectType: 'input' }
             )
             cy.get("[data-cy='company-logo-uploaded']").should('have.attr', 'src')

--- a/src/components/JobTemplate.js
+++ b/src/components/JobTemplate.js
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom'
 
 const JobTemplate = ({ logo, props }) => {
   let { pathname } = useLocation()
-  const isDisabled = pathname.indexOf('/job-board/') !== 0
+  const isPreview = pathname.indexOf('/job-board/') !== 0
 
   const [companyLogo, setCompanyLogo] = useState(undefined)
 
@@ -60,11 +60,13 @@ const JobTemplate = ({ logo, props }) => {
     const companyChildren = [...companyDescription.children]
     styleChildren(companyChildren)
 
-    // Setting Logo in new job post preview
-    readLogo(logo)
-
-    // Retrieve logo to display in live job posting
-    retrieveLogo()
+    if (isPreview) {
+      // Setting Logo in new job post preview
+      readLogo(logo)
+    } else {
+      // Retrieve logo to display in live job posting
+      retrieveLogo()
+    }
   })
 
   function createMarkup(text) {
@@ -149,8 +151,8 @@ const JobTemplate = ({ logo, props }) => {
                 </a>
                 <a data-cy='how-to-apply' href={props.howToApply}>
                   <button
-                    disabled={isDisabled}
-                    className={'hidden md:block btn btn-teal mt-8 w-full' + (isDisabled ? ' btn-disabled' : '')}>
+                    disabled={isPreview}
+                    className={'hidden md:block btn btn-teal mt-8 w-full' + (isPreview ? ' btn-disabled' : '')}>
                     Apply
                   </button>
                 </a>
@@ -162,8 +164,8 @@ const JobTemplate = ({ logo, props }) => {
         <div>
           <a data-cy='how-to-apply-bottom' href={props.howToApply}>
             <button
-              disabled={isDisabled}
-              className={'btn btn-teal mt-8 w-full md:w-auto' + (isDisabled ? ' btn-disabled' : '')}>
+              disabled={isPreview}
+              className={'btn btn-teal mt-8 w-full md:w-auto' + (isPreview ? ' btn-disabled' : '')}>
               Apply
             </button>
           </a>

--- a/src/components/form/LogoUpload.js
+++ b/src/components/form/LogoUpload.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-function LogoUpload({ recievingLogo }, props) {
+function LogoUpload({ recievingLogo, ...props }) {
   const [fileResult, setFileResult] = useState(undefined)
   const [fileName, setFileName] = useState('')
 
@@ -15,6 +15,7 @@ function LogoUpload({ recievingLogo }, props) {
       reader.onloadend = () => {
         setFileName(file.name)
         setFileResult(reader.result)
+        props.setFieldValue('companyLogo', file)
         recievingLogo(file)
       }
     }
@@ -44,7 +45,7 @@ function LogoUpload({ recievingLogo }, props) {
             name='companyLogo'
             className='hidden'
             type='file'
-            accept='image/*'
+            accept='image/png'
           ></input>
         </label>
       </div>
@@ -55,7 +56,7 @@ function LogoUpload({ recievingLogo }, props) {
         >
           {fileName
             ? `Uploaded: ${fileName}`
-            : 'Please provide a .png format of your companies logo to be displayed with your job opening listing.'}
+            : "Please provide a .png format of your company's logo to be displayed with your job opening listing."}
         </span>
       </div>
     </div>

--- a/src/components/form/PostAJobForm.js
+++ b/src/components/form/PostAJobForm.js
@@ -55,7 +55,8 @@ const PostAJobForm = ({
           companyDescription: Yup.string().required(
             'Please give a brief description of the company and culture.'
           ),
-          companyLogo: Yup.mixed(),
+          companyLogo: Yup.mixed().required('Please provide a .png format image of your company logo')
+            .test(file => file && file.type === 'image/png'),
           companyHQ: Yup.string().required(
             'Please provide a location for your office headquarters.'
           ),
@@ -325,6 +326,7 @@ const PostAJobForm = ({
                         component={LogoUpload}
                         recievingLogo={recievingLogo}
                         value={fileValue}
+                        setFieldValue={formik.setFieldValue}
                       />
 
                       <ErrorMessage

--- a/src/pages/PostAJob.js
+++ b/src/pages/PostAJob.js
@@ -27,7 +27,6 @@ const PostAJob = () => {
 
   function recievingTemplateApproval(e) {
     setStatus(3)
-    console.log(companyLogo)
     sendJobToDB({ jobData, companyLogo })
   }
 


### PR DESCRIPTION
I noticed that posting a job fails without a company logo:

<img width="560" alt="No Logo Error" src="https://user-images.githubusercontent.com/44448047/88462457-fe84da80-ce70-11ea-89c5-165bfa788cba.png">

So I added validations to require a .png file.

There are checks in other components for the presence of a logo, so if we require a logo we could eliminate those. But maybe you want logos to be optional? Let me know! 

I also changed the JobTemplate to only retrieve the logo from firebase if the post is live on the board.