### PR TITLE
Remove font awesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,43 +1537,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.38.tgz",
       "integrity": "sha512-mp1XmAJsuqaSWm5WQYo7R0zfZWe9EmwMCxsxkKr+ubLOumyNy4NG5aV45hEpFTosQv4myXpiCiS4GFE9mNqLZQ=="
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.30",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
-      "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz",
-      "integrity": "sha512-4LeaNHWvrneoU0i8b5RTOJHKx7E+y7jYejplR7uSVB34+mp3Veg7cbKk7NBCLiI4TyoWS1wh9ZdoyLJR8wSAdg==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
-      }
-    },
-    "@fortawesome/free-brands-svg-icons": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-/6xXiJFCMEQxqxXbL0FPJpwq5Cv6MRrjsbJEmH/t5vOvB4dILDpnY0f7zZSlA8+TG7jwlt12miF/yZpZkykucA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz",
-      "integrity": "sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "@grpc/grpc-js": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.28",
-    "@fortawesome/free-brands-svg-icons": "^5.13.0",
-    "@fortawesome/free-solid-svg-icons": "^5.13.0",
-    "@fortawesome/react-fontawesome": "^0.1.9",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import * as ROUTES from '../constants/routes'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
 
 const Nav = () => {
   const [active, setActive] = React.useState(false)
@@ -25,7 +23,26 @@ const Nav = () => {
           className='nav-toggle relative md:hidden text-3xl p-3'
           onClick={() => setActive((oldActive) => !oldActive)}
         >
-          <FontAwesomeIcon icon={faBars} />
+          <svg
+            style={{
+              overflow: 'visible',
+              width: `0.875em`,
+              display: `inline-block`,
+              fontSize: `inherit`,
+              height: `1em`,
+              verticalAlign: `-0.125em`,
+            }}
+            aria-hidden='true'
+            focusable='false'
+            role='img'
+            xmlns='http://www.w3.org/2000/svg'
+            viewBox='0 0 448 512'
+          >
+            <path
+              fill='currentColor'
+              d='M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z'
+            ></path>
+          </svg>
         </button>
 
         <ul


### PR DESCRIPTION
Unless there are big plans to use font awesome, we can save some bundle size and improve performance by using an svg directly instead.

- Use `<svg>` for nav toggle button
- Remove Font Awesome from packages