### PR TITLE
Fixed issue where additional contributor info was missing in profile.

### DIFF
--- a/bin/generate-contributors-json.js
+++ b/bin/generate-contributors-json.js
@@ -63,14 +63,23 @@ async function generateContributorsJson() {
       '✅ Received the list of contributors for the repository https://github.com/drewclem/protege.'
     )
 
+    const individualContributorResponses = await Promise.all(
+      rawContributors.map(({ url }) => fetch(url))
+    )
+
     const individualContributorInfos = await Promise.all(
-      rawContributors.map((url) => url)
+      individualContributorResponses.map((response) => response.json())
     )
 
     console.log('✅ Received additional information for contributors')
 
     const contributors = rawContributors.map((contributor, index) => {
-      return { ...contributor, ...individualContributorInfos[index] }
+      const fullContributorProfileInfo = {
+        ...contributor,
+        ...individualContributorInfos[index],
+      }
+
+      return fullContributorProfileInfo
     })
 
     await mkdir(dataFolder, { recursive: true })


### PR DESCRIPTION
In my previous work in #115, I created a regression. There was missing contributor profile information with my change. This fixes that. TLDR, the additional profile info was not being pulled properly.

## Before

![image](https://user-images.githubusercontent.com/833231/90896026-f5642c00-e390-11ea-9a9f-cbacedabb564.png)

## After

![image](https://user-images.githubusercontent.com/833231/90895994-e7161000-e390-11ea-88ab-a575a3e4cfee.png)

![Chris Pratt in Parks and Recreation making faces that indicate oops](https://media.giphy.com/media/BsQAVgY6ksvIY/giphy.gif)