### PR TITLE
Reenable eslint on build command

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -35,10 +35,5 @@ module.exports = {
     FB_TOKEN_URI: process.env.FB_TOKEN_URI,
     FB_AUTH_PROVIDER_X509_CERT_URL: process.env.FB_AUTH_PROVIDER_X509_CERT_URL,
     FB_CLIENT_X509_CERT_URL: process.env.FB_CLIENT_X509_CERT_URL,
-  },
-  eslint: {
-    // Warning: Dangerously allow production builds to successfully complete even if
-    // your project has ESLint errors.
-    ignoreDuringBuilds: true,
-  },
-}
+        }
+  }


### PR DESCRIPTION
Closes #325

# Description

As per @nickytonline description: On build now with NEXT.js 11, eslint runs as part of the build. Currently it's erroring out with the following lint errors. Reenable linting on builds and fix the lint errors.

# Related Tickets and Documents

Issue #325 

## What gif best describes this PR or how it makes you feel? (optional)

![](https://media1.giphy.com/media/nDMyoNRkCesJdZAuuL/giphy-downsized-medium.gif)